### PR TITLE
allow requests to same organization domains for world's top100 domains

### DIFF
--- a/official-allow_sameorg.json
+++ b/official-allow_sameorg.json
@@ -1,7 +1,7 @@
 {
   "metadata":{
     "version":1,
-    "serial":2014120101
+    "serial":2014120401
   },
   "entries":{
     "allow":[

--- a/official.json
+++ b/official.json
@@ -5,7 +5,7 @@
       "url":"https://raw.githubusercontent.com/RequestPolicyContinued/subscriptions/master/official-allow_embedded.json"
     },
     "allow_sameorg":{
-      "serial"::2014120101,
+      "serial":2014120401,
       "url":"https://raw.githubusercontent.com/RequestPolicyContinued/subscriptions/master/official-allow_sameorg.json"
     },
     "deny_trackers":{


### PR DESCRIPTION
- top100 data from http://www.alexa.com/topsites
- remove wrong rules (akamaihd and cloudfront CDNs are not the same organization as origin domains)
