### PR TITLE
create Makefile with a check for duplicate lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+# NOTE: in this file tab indentation is used.
+# Otherwise .RECIPEPREFIX would have to be set.
+
+#
+# create variables
+#
+
+subscription_lists := official.json
+
+# subscriptions are all json file except those in $(subscription_lists)
+all_json_files := $(wildcard *.json)
+subscriptions := $(filter-out $(subscription_lists),$(all_json_files))
+
+
+#
+# define targets
+#
+
+# set "check" to be the default target
+.DEFAULT_GOAL := check
+
+# all checks and their order of execution
+checks := check_json_validity \
+	check_duplicate_lines
+
+.PHONY: check test
+.PHONY: $(checks)
+check test: $(checks)
+
+check_json_validity:
+	# check_json_validity not implemented yet
+
+
+# _________________________
+# check for duplicate lines
+#
+
+duplicate_rules := $(shell egrep -ho '\{.*\}' $(subscriptions) | sort | uniq -d)
+duplicate_rules_quoted := $(addprefix ',$(addsuffix ',$(duplicate_rules)))
+
+check_duplicate_lines:
+	@# go through all duplicates and report in which subscription files they are
+	@for rule in $(duplicate_rules_quoted) ; do \
+		echo '___Duplicate rule___' ; \
+		fgrep -nHT $$rule $(subscriptions) ; \
+	done


### PR DESCRIPTION
see #14

I have to say `make` and bash are quite inconvenient for this task, especially for working with strings that might contain quotes. What do you think @nodiscc? Maybe better use python/javascript/…? Btw, there are programs like [grunt](http://gruntjs.com/) or [gulp](http://gulpjs.com/).