### PR TITLE
move subscriptions titles and description directly in official.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,29 +78,35 @@ function rprule() {
 
 Additions to the _deny trackers_ list are also welcome.
 
+#### Translating subscriptions titles and descriptions
+Look at `locale.json` and feel free to add the translations for subscriptions titles and language there.
+
 
 --------------------------------------------------------------------------------
 
 ## How to read subscriptions files
-RequestPolicy Continued fetches available subscriptions from **subscription lists**. [official.json](official.json) is the default subscription list (the only list currently) Each **subscription list** lists several **subscriptions**.
+RequestPolicy Continued fetches available subscriptions from **subscription lists**. [official.json](official.json) is the default subscription list (the only list currently) Each **subscription list** lists several **subscriptions**, which contain the actual rules.
 
 
 
-The subscriptions **lists** file format is the following:
+The **subscriptions lists** file format is the following (eg. `official.json`):
 
 ```
 {
   "subscriptions":{ 
     "allow_embedded":{ <- short name of the subscription.
-      "serial":1329159661, <- a serial number; RP compares your local file serial number to the one available online, and updates you file if it has a lower serial.
-      "url":"https://raw.githubusercontent.com/RequestPolicyContinued/subscriptions/master/official-allow_embedded.json", <- the URL from which the new subscriptions should be downloaded
+      "serial":1329159661, <- a serial number; RP compares your local file serial number to the one available online, and updates your file if it has a lower serial.
+      "url":"https://raw.githubusercontent.com/RequestPolicyContinued/subscriptions/master/official-allow_embedded.json", <- the URL from which up-to-date subscription rules should be downloaded
       "title":"Your title here", <- the title of this subscription
-      "description":"This subscription does this." <- a description of what purpose this subscription serves, how it work
+      "description":"This subscription does this." <- a description of what purpose this subscription serves, how it works
       },
     "another_subscription_here": { ...
 ```
 
-The subscription file format is the following:
+`locale.json` contains translations for each subscription's list and title.
+
+
+The **subscription** file format is the following (eg. `official-allow_functionality.json`):
 
 ```
 {

--- a/locale.json
+++ b/locale.json
@@ -7,15 +7,15 @@
       },
       "allow_functionality":{
         "title":"Accepter les requêtes nécessaires aux fonctionnement de certains sites Web",
-        "description":"Contient des règles 'accepter' qui permettent à certains sites de s'afficher et de fonctionner correctement, même si le propriétaire du domaine de destination de la requête n'est pas le même que celui du domaine d'origine. Les règles pour les fonctionnalités qui ne font pas partie des fonctionnalités de base des sites ne sont pas incluses."
+        "description":"Contient des règles 'accepter' absolument nécessaires pour un bon fonctionnement des fonctionnalités principales de certains sites, même si le propriétaire du domaine de destination de la requête n'est pas le même que celui du domaine d'origine."
       },
       "allow_sameorg":{
         "title":"Accepter les requêtes vers des destinations appartenant à la même organisation que le domaine d'origine",
-        "description":"Contient uniquement des règles 'accepter' absolument nécessaires pour un bon fonctionnement des fonctionnalités principales des sites. Si le domaine de destination n'appartient pas à la même organisation, personne, ou société que le domaine d'origine, la règle ne doit pas êtreincluse dans cette souscription."
+        "description":"Contient des règles 'accepter' absolument nécessaires pour un bon fonctionnement des fonctionnalités principales de certains sites, ET dont le propriétaire du domaine de destination de la requête est le même que celui du domaine d'origine."
       },
       "deny_trackers":{
         "title":"Bloquer les requêtes vers des domaines connus pour tracer votre navigation",
-        "description":"Cette souscription contient une liste de domaines connus pour surveiller/tracer votre navigation à travers le Web. Elle est particulièrement utilepour fournir une sécurité/confidentialité minimale si vous utilisez _Accepter les requêtes_ comme politique par défaut."
+        "description":"Cette souscription contient une liste de domaines connus pour surveiller/tracer votre navigation à travers le Web. Elle est particulièrement utile pour fournir une sécurité/confidentialité minimale si vous utilisez _Accepter les requêtes_ comme politique par défaut."
       }
     }
   }

--- a/official.json
+++ b/official.json
@@ -1,6 +1,6 @@
 {
   "l10n":{
-    "serial":2014122401,
+    "serial":2014122601,
     "url":"https://raw.githubusercontent.com/RequestPolicyContinued/subscriptions/master/locale.json"
   },
   "subscriptions":{


### PR DESCRIPTION
- work on https://github.com/RequestPolicyContinued/subscriptions/issues/1

I think this can be done safely as it makes the README more readable, conveys more information directly in the subscription list, and does not break current mechanisms.
