### PR TITLE
Added Twitch TV related domains

### DIFF
--- a/official-allow_sameorg.json
+++ b/official-allow_sameorg.json
@@ -161,6 +161,8 @@
       {"o":{"h":"*.wireshark.net"},"d":{"h":"*.wireshark.org"}},
       {"o":{"h":"*.msn.com"},"d":{"h":"*.s-msn.com"}},
       {"o":{"h":"*.twitch.tv"},"d":{"h":"*.jtvnw.net"}},
+      {"o":{"h":"*.twitch.tv"},"d":{"h":"*.justin.tv"}},
+      {"o":{"h":"*.twitch.tv"},"d":{"h":"*.ttvnw.net"}},
       {"o":{"h":"*.websitegrader.com"},"d":{"h":"*.grader.com"}},
       {"o":{"h":"*.grader.com"},"d":{"h":"*.hsappstatic.net"}},
       {"o":{"h":"*.flattr.com"},"d":{"h":"*.flattr.net"}},


### PR DESCRIPTION
Needed for proper functionality - ttvnw.net for browsing games/channels, justin.tv to load the streams; Twitch Interactive, Inc. is the organization for all of them